### PR TITLE
[WIP] Add Podspec

### DIFF
--- a/GLTFSceneKit.podspec
+++ b/GLTFSceneKit.podspec
@@ -1,0 +1,18 @@
+Pod::Spec.new do |s|
+  s.name = "GLTFSceneKit"
+  s.version = "0.0.1"
+  s.summary = "glTF loader for SceneKit"
+  s.homepage = "https://github.com/magicien/GLTFSceneKit"
+  s.license = "MIT"
+  s.author = "magicien"
+  s.ios.deployment_target = "11.0"
+  s.osx.deployment_target = "10.12"
+  s.source = { :git => "https://github.com/magicien/GLTFSceneKit.git", :tag => "v#{s.version}" }
+  s.source_files = "Source/**/*.swift"
+  s.resources = "Source/**/*.shader"
+  s.requires_arc = true
+  s.pod_target_xcconfig = {
+    "SWIFT_VERSION" => "4.0",
+    "SWIFT_ACTIVE_COMPILATION_CONDITIONS" => "SEEMS_TO_HAVE_VALIDATE_VERTEX_ATTRIBUTE_BUG SEEMS_TO_HAVE_PNG_LOADING_BUG"
+  }
+end

--- a/README.md
+++ b/README.md
@@ -1,2 +1,11 @@
 # GLTFSceneKit
 glTF loader for SceneKit
+
+## Installation
+### Using [CocoaPods](http://cocoapods.org/)
+
+Add the following to your [Podfile](http://guides.cocoapods.org/using/the-podfile.html):
+
+```rb
+pod 'GLTFSceneKit'
+```


### PR DESCRIPTION
I have made a Podspec so CocoaPods users can easily consume this library. When I used the `pods spec create` command, this was printed on the terminal:

---

I’ve recently added [GLTFSceneKit](https://github.com/CocoaPods/Specs/tree/master/GLTFSceneKit) to the [CocoaPods](https://github.com/CocoaPods/CocoaPods) package manager repo.

CocoaPods is a tool for managing dependencies for OSX and iOS Xcode projects and provides a central repository for iOS/OSX libraries. This makes adding libraries to a project and updating them extremely easy and it will help users to resolve dependencies of the libraries they use.

However, GLTFSceneKit doesn't have any version tags. I’ve added the current HEAD as version 0.0.1, but a version tag will make dependency resolution much easier.

[Semantic version](http://semver.org) tags (instead of plain commit hashes/revisions) allow for [resolution of cross-dependencies](https://github.com/CocoaPods/Specs/wiki/Cross-dependencies-resolution-example).

In case you didn’t know this yet; you can tag the current HEAD as, for instance, version 1.0.0, like so:

```
$ git tag -a 1.0.0 -m "Tag release 1.0.0"
$ git push --tags
```

---

I currently write `pod 'GLTFSceneKit', :git => 'https://github.com/AlicanC/GLTFSceneKit.git', :commit => 'cdef212daab7d5a625efa6819111eeb31d6e7d7e'` to consume and if you can tag and push a version, then I guess I could put this Podspec in the CocoaPods master repo so users can just use `pod 'GLTFSceneKit'` to consume.