### PR TITLE
Sort loaded attributes to keep semantic order

### DIFF
--- a/Source/Common/GLTFUnarchiver.swift
+++ b/Source/Common/GLTFUnarchiver.swift
@@ -1110,8 +1110,8 @@ public class GLTFUnarchiver {
     
     private func loadAttributes(_ attributes: [String: GLTFGlTFid]) throws -> [SCNGeometrySource] {
         var sources = [SCNGeometrySource]()
-        
-        for (attribute, accessorIndex) in attributes {
+        // Sort attributes to keep correct semantic order
+        for (attribute, accessorIndex) in attributes.sorted(by: { $0.0 < $1.0 }) {
             if let semantic = attributeMap[attribute] {
                 let accessor = try self.loadVertexAccessor(index: accessorIndex, semantic: semantic)
                 sources.append(accessor)


### PR DESCRIPTION
This change fix issues where multiple texcoords (and other semantics?) might be loaded in an incorrect order, resulting in incorrect rendering of the 3D model