### PR TITLE
Added this transparency fix

### DIFF
--- a/Source/Common/GLTFUnarchiver.swift
+++ b/Source/Common/GLTFUnarchiver.swift
@@ -1048,6 +1048,7 @@ public class GLTFUnarchiver {
             material.blendMode = .replace
         case "BLEND":
             material.blendMode = .alpha
+            material.writesToDepthBuffer = false
             material.shaderModifiers![.surface] = try! String(contentsOf: URL(fileURLWithPath: Bundle(for: GLTFUnarchiver.self).path(forResource: "GLTFShaderModifierSurface_alphaModeBlend", ofType: "shader")!), encoding: String.Encoding.utf8)
         case "MASK":
             material.shaderModifiers![.fragment] = try! String(contentsOf: URL(fileURLWithPath: Bundle(for: GLTFUnarchiver.self).path(forResource: "GLTFShaderModifierFragment_alphaCutoff", ofType: "shader")!), encoding: String.Encoding.utf8)


### PR DESCRIPTION
I added this line for the transparent objects, 

it makes the stuff behind them come through and actually look like its transparent and you can see through it. 

By not writing to the depth buffer, transparent objects will not occlude themselves, like you can see in the pictures i'll put. 



Before
![image](https://user-images.githubusercontent.com/6535806/33668502-effbacae-da6d-11e7-8939-0bb0cdd991b9.png)

After
![image](https://user-images.githubusercontent.com/6535806/33668509-f805856e-da6d-11e7-93bc-9e2dea6e0a25.png)

