### PR TITLE
Assign accessor names to morph targets

### DIFF
--- a/Source/Common/GLTFUnarchiver.swift
+++ b/Source/Common/GLTFUnarchiver.swift
@@ -1163,7 +1163,6 @@ public class GLTFUnarchiver {
                     let accessor = self.json.accessors?[targetIndex]
                     
                     if let name = accessor?.name {
-                        print("geometry name: \(name)")
                         geometry.name = name
                     }
 

--- a/Source/Common/GLTFUnarchiver.swift
+++ b/Source/Common/GLTFUnarchiver.swift
@@ -1160,6 +1160,13 @@ public class GLTFUnarchiver {
                     let target = targets[targetIndex]
                     let sources = try self.loadAttributes(target)
                     let geometry = SCNGeometry(sources: sources, elements: nil)
+                    let accessor = self.json.accessors?[targetIndex]
+                    
+                    if let name = accessor?.name {
+                        print("geometry name: \(name)")
+                        geometry.name = name
+                    }
+
                     morpher.targets.append(geometry)
                     let weightPath = "childNodes[0].childNodes[\(i)].morpher.weights[\(targetIndex)]"
                     weightPaths.append(weightPath)

--- a/Source/Common/GLTFUnarchiver.swift
+++ b/Source/Common/GLTFUnarchiver.swift
@@ -1160,9 +1160,8 @@ public class GLTFUnarchiver {
                     let target = targets[targetIndex]
                     let sources = try self.loadAttributes(target)
                     let geometry = SCNGeometry(sources: sources, elements: nil)
-                    let accessor = self.json.accessors?[targetIndex]
-                    
-                    if let name = accessor?.name {
+
+                    if let accessor = self.json.accessors?[target["POSITION"]!], let name = accessor.name {
                         geometry.name = name
                     }
 


### PR DESCRIPTION
If an accessor has a name, it's morph target should also be named. This is done in the glTF Models repo to name morph targets; see [AnimatedMorphCube]. 

[AnimatedMorphCube]: https://github.com/KhronosGroup/glTF-Sample-Models/blob/master/2.0/AnimatedMorphCube/glTF/AnimatedMorphCube.gltf#L36