### PR TITLE
support JOINTS_1 and WEIGHTS_1

### DIFF
--- a/Source/Common/GLTFTypes.swift
+++ b/Source/Common/GLTFTypes.swift
@@ -16,7 +16,9 @@ let attributeMap: [String: SCNGeometrySource.Semantic] = [
     "TEXCOORD_1": SCNGeometrySource.Semantic.texcoord,
     "COLOR_0": SCNGeometrySource.Semantic.color,
     "JOINTS_0": SCNGeometrySource.Semantic.boneIndices,
-    "WEIGHTS_0": SCNGeometrySource.Semantic.boneWeights
+    "JOINTS_1": SCNGeometrySource.Semantic.boneIndices,
+    "WEIGHTS_0": SCNGeometrySource.Semantic.boneWeights,
+    "WEIGHTS_1": SCNGeometrySource.Semantic.boneWeights
 ]
 
 let GLTF_BYTE = Int(GL_BYTE)


### PR DESCRIPTION
Is this really all that's required to support a second joint/weight attribute pair?

This change does make my model load successfully. I do see the animation I expect to see.

I'm not sure whether the 2nd joint/attribute pair is actually being used.

Issue: #21 