### PR TITLE
GLTFUnarchiver + GLTFSceneSource: add embedExternalImages option

### DIFF
--- a/Source/Common/GLTFSceneSource.swift
+++ b/Source/Common/GLTFSceneSource.swift
@@ -16,22 +16,22 @@ public class GLTFSceneSource : SCNSceneSource {
         super.init()
     }
     
-    public convenience init(path: String, options: [SCNSceneSource.LoadingOption : Any]? = nil, extensions: [String:Codable.Type]? = nil) throws {
+    public convenience init(path: String, options: [SCNSceneSource.LoadingOption : Any]? = nil, extensions: [String:Codable.Type]? = nil, embedExternalImages: Bool = true) throws {
         self.init()
         
-        let loader = try GLTFUnarchiver(path: path, extensions: extensions)
+        let loader = try GLTFUnarchiver(path: path, extensions: extensions, embedExternalImages: embedExternalImages)
         self.loader = loader
     }
     
     public override convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]? = nil) {
-        self.init(url: url, options: options, extensions: nil)
+        self.init(url: url, options: options, extensions: nil, embedExternalImages: true)
     }
     
-    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]?, extensions: [String:Codable.Type]?) {
+    public convenience init(url: URL, options: [SCNSceneSource.LoadingOption : Any]?, extensions: [String:Codable.Type]?, embedExternalImages: Bool = true) {
         self.init()
         
         do {
-            self.loader = try GLTFUnarchiver(url: url, extensions: extensions)
+            self.loader = try GLTFUnarchiver(url: url, extensions: extensions, embedExternalImages: embedExternalImages)
         } catch {
             print("\(error.localizedDescription)")
         }


### PR DESCRIPTION
During development on an internal tool, a colleague and I needed an option to suppress GLTFSceneKit’s default behavior of embedding external image data into a SceneKit file.

This PR achieves that by adding a `embedExternalImages` option to `GTFSceneSource` constructor, which is `true` by default, thereby matching GLTFSceneKit’s current behavior.

When the setting is `false`, a `GLTFUnarchiver` class instance will return a `URL` to an image, as extracted from a `.gltf` file, rather than `Image` data.