### PR TITLE
removed unnecessary extra SCNNodes during loading

### DIFF
--- a/Source/Common/GLTFUnarchiver.swift
+++ b/Source/Common/GLTFUnarchiver.swift
@@ -1100,7 +1100,7 @@ public class GLTFUnarchiver {
         var weightPaths = [String]()
         for i in 0..<glMesh.primitives.count {
             let primitive = glMesh.primitives[i]
-            let primitiveNode = SCNNode()
+            
             //var sources = [SCNGeometrySource]()
             //var vertexSource: SCNGeometrySource?
             //var normalSource: SCNGeometrySource?
@@ -1146,7 +1146,7 @@ public class GLTFUnarchiver {
             }
             
             let geometry = SCNGeometry(sources: sources, elements: elements)
-            primitiveNode.geometry = geometry
+            node.geometry = geometry
             
             if let materialIndex = primitive.material {
                 let material = try self.loadMaterial(index: materialIndex)
@@ -1173,10 +1173,9 @@ public class GLTFUnarchiver {
                     
                 }
                 morpher.calculationMode = .additive
-                primitiveNode.morpher = morpher
+                node.morpher = morpher
             }
             
-            node.addChildNode(primitiveNode)
         }
         
         // TODO: set default weights
@@ -1596,7 +1595,7 @@ public class GLTFUnarchiver {
             throw GLTFUnarchiveError.DataInconsistent("loadNode: nodes is not defined")
         }
         let glNode = nodes[index]
-        let scnNode = SCNNode()
+        var scnNode = SCNNode()
         self.nodes[index] = scnNode
         
         if let name = glNode.name {
@@ -1606,12 +1605,11 @@ public class GLTFUnarchiver {
             scnNode.camera = try self.loadCamera(index: camera)
         }
         if let mesh = glNode.mesh {
-            let meshNode = try self.loadMesh(index: mesh)
-            scnNode.addChildNode(meshNode)
+            scnNode = try self.loadMesh(index: mesh)
             
             var weightPaths = [String]()
-            for i in 0..<meshNode.childNodes.count {
-                let primitive = meshNode.childNodes[i]
+            for i in 0..<scnNode.childNodes.count {
+                let primitive = scnNode.childNodes[i]
                 if let morpher = primitive.morpher {
                     for j in 0..<morpher.targets.count {
                         let path = "childNodes[0].childNodes[\(i)].morpher.weights[\(j)]"
@@ -1622,7 +1620,7 @@ public class GLTFUnarchiver {
             scnNode.setValue(weightPaths, forUndefinedKey: "weightPaths")
             
             if let skin = glNode.skin {
-                _ = try self.loadSkin(index: skin, meshNode: meshNode)
+                _ = try self.loadSkin(index: skin, meshNode: scnNode)
                 //scnNode.skinner = skinner
             }
         }


### PR DESCRIPTION
During the loading from `glb` into `Scenekit` there are excess nodes being added to the SceneKit hierarchy that don't exist in the `glb` file. This is a major problem for anyone working with models where you need to target specific children using their names.

Within `loadNode` and `loadMesh` there are arbitrary nodes added to the hierarchy which cause there to be duplicate nodes with the same name causing issues with using functions that traverse the scene graph. 

For example `rootNode.childNode(withName: _)` returns the parent to the node you actually are looking for. To work around this distorted hierarchy you have to call the method twice first to get the arbitrary parent and then again on this parent to find the child node you actually want. Or when attempting to set the material on a node that should have geometry you have to use `node.childNodes.firstChild.geometry` instead of `node.geometry`. 

In my proposed update:

1. I updated `loadNode` to get rid of the extra node, changing `scnNode` from a `let` to a `var` and then instead of creating a new node with `meshNode` I set the return from `loadMesh` directly to `scnNode`

2. I remove `primitiveNode` entirely from `loadMesh` and instead assign everything that was assigned to `primitiveNode` to `node` 

Upon testing it reduces the number of arbitrary parents. For example when querying for a specific node using `.childNode(withName: _)`, the first result is the correct node we want, no longer do we have to search the first result for a child with the same name. Also this solution allows for updating materials without having to get the first child node to find the geometry of the named node. 

> Note: This is a breaking change for anyone that has written work arounds, but this properly passes the `glb` hierarchy to the SCN.
