### PR TITLE
Fix OpenGL imports on macOS

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+.swiftpm
+
 # Xcode
 #
 *.DS_Store

--- a/Sources/GLTFSceneKit/GLTFTypes.swift
+++ b/Sources/GLTFSceneKit/GLTFTypes.swift
@@ -7,6 +7,7 @@
 //
 
 import SceneKit
+import OpenGL
 
 let attributeMap: [String: SCNGeometrySource.Semantic] = [
     "POSITION": SCNGeometrySource.Semantic.vertex,


### PR DESCRIPTION
In some build configurations, there's an error where all of the GL types
(like `GL_BYTE`, `GL_UNSIGNED_INT`, etc.) cannot be found. This should
rectify the issue
